### PR TITLE
Show the duration it took to process a request (in trace/debug mode only)

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -7,6 +7,7 @@ package aah
 import (
 	"net/http"
 	"reflect"
+	"time"
 
 	"aahframework.org/log.v0-unstable"
 )
@@ -102,6 +103,7 @@ func interceptorMiddleware(ctx *Context, m *Middleware) {
 	target := reflect.ValueOf(ctx.target)
 	controller := resolveControllerName(ctx)
 
+	startTime := time.Now()
 	// Finally action and method
 	defer func() {
 		if ctx.abort {
@@ -117,6 +119,8 @@ func interceptorMiddleware(ctx *Context, m *Middleware) {
 			log.Debugf("Calling interceptor: %s.%s", controller, incpFinallyActionName)
 			finallyAction.Call(emptyArg)
 		}
+
+		log.Debugf("Request took %v", time.Now().Sub(startTime))
 	}()
 
 	// Panic action and method


### PR DESCRIPTION
It is totally fine f you do not want this in. I can make use of a custom middleware that does this (and an extensive logging of the request - equestID, HTTPMethod, status code and the duration it took to process the request ).