### PR TITLE
#141 removed "static" directory hardcode value. now its configured from routes.conf

### DIFF
--- a/static.go
+++ b/static.go
@@ -24,7 +24,6 @@ import (
 )
 
 const (
-	dirStatic             = "static"
 	sniffLen              = 512
 	noCacheHdrValue       = "no-cache, no-store, must-revalidate"
 	dirListDateTimeFormat = "2006-01-02 15:04:05"
@@ -189,7 +188,7 @@ func checkGzipRequired(file string) bool {
 // Note: `ctx.route.*` values come from application routes configuration.
 func getHTTPDirAndFilePath(ctx *Context) (http.Dir, string) {
 	if ctx.route.IsFile() { // this is configured value from routes.conf
-		return http.Dir(filepath.Join(AppBaseDir(), dirStatic)),
+		return http.Dir(filepath.Join(AppBaseDir(), ctx.route.Dir)),
 			parseCacheBustPart(ctx.route.File, AppBuildInfo().Version)
 	}
 	return http.Dir(filepath.Join(AppBaseDir(), ctx.route.Dir)),

--- a/static_test.go
+++ b/static_test.go
@@ -33,7 +33,7 @@ func TestStaticFileAndDirectoryListing(t *testing.T) {
 	testStaticServe(t, e, "http://localhost:8080/static/test.txt", "static", "test.txt", "", "This is file content of test.txt", false)
 
 	appIsProfileProd = true
-	testStaticServe(t, e, "http://localhost:8080/robots.txt", "", "", "test.txt", "This is file content of test.txt", false)
+	testStaticServe(t, e, "http://localhost:8080/robots.txt", "static", "", "test.txt", "This is file content of test.txt", false)
 	appIsProfileProd = false
 }
 


### PR DESCRIPTION
Implementation of #141 
- added "base_dir" attribute support for static file mapping and fallback to "public_assets.dir"