### PR TITLE
Auth info merge

### DIFF
--- a/security/authz/authorization_info.go
+++ b/security/authz/authorization_info.go
@@ -39,6 +39,28 @@ type AuthorizationInfo struct {
 	permissions []*Permission
 }
 
+// Merge create a new AuthorizationInfo by mergeing two AuthorizationInfo.
+// Creates a deep copy of permissions. Does not remove duplicates.
+func (a *AuthorizationInfo) Merge(authInfo *AuthorizationInfo) *AuthorizationInfo {
+	n := NewAuthorizationInfo()
+
+	n.roles = append(a.roles, authInfo.roles...)
+
+	for _, src := range a.permissions {
+		dst := &Permission{parts: make([]parts, len(src.parts))}
+		copy(dst.parts, src.parts)
+		n.permissions = append(n.permissions, dst)
+	}
+
+	for _, src := range authInfo.permissions {
+		dst := &Permission{parts: make([]parts, len(src.parts))}
+		copy(dst.parts, src.parts)
+		n.permissions = append(n.permissions, dst)
+	}
+
+	return n
+}
+
 // AddRole method assigns a multiple-role to those associated with the account.
 func (a *AuthorizationInfo) AddRole(roles ...string) *AuthorizationInfo {
 	a.roles = append(a.roles, roles...)

--- a/security/authz/authorization_info_test.go
+++ b/security/authz/authorization_info_test.go
@@ -45,3 +45,17 @@ func TestAuthAuthorizationPermissions(t *testing.T) {
 	assert.False(t, a2.IsPermitted("newsletter:write"))
 	assert.False(t, a2.IsPermittedAll("newsletter:read", "newsletter:write"))
 }
+
+func TestAuthAuthorizationMerge(t *testing.T) {
+
+	a1 := NewAuthorizationInfo()
+	a1.AddPermissionString("newsletter:*:*")
+	a1.AddRole("role1", "role2", "role3", "role4")
+
+	a2 := NewAuthorizationInfo()
+	a2.AddPermissionString("newsletter:read:1111")
+	a2.AddRole("role5", "role6")
+
+	a3 := a1.Merge(a2)
+	assert.Equal(t, "authorizationinfo(roles(role1, role2, role3, role4, role5, role6) allpermissions(permission(newsletter:*:*)|permission(newsletter:read:1111)))", a3.String())
+}


### PR DESCRIPTION
We would like to have the ability to inherit permissions from a team to a user. **Merge()** will do exactly this. It makes the authorization logic simpler in some places. 